### PR TITLE
delete-cable-js

### DIFF
--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -1,4 +1,4 @@
-touch app/javascript/plugins/init_autocomplete.js// Action Cable provides the framework to deal with WebSockets in Rails.
+// Action Cable provides the framework to deal with WebSockets in Rails.
 // You can generate new channels where WebSocket features live using the `rails generate channel` command.
 //
 //= require action_cable


### PR DESCRIPTION
Suppression de la première ligne dans app/assets/javascripts/cable.js pour pouvoir utiliser du js

